### PR TITLE
Feature/issue 8/add sound to maya playblast publishes

### DIFF
--- a/hooks/tk-maya/render_media.py
+++ b/hooks/tk-maya/render_media.py
@@ -39,7 +39,7 @@ class RenderMedia(HookBaseClass):
             version,
             engine_settings,
             sound_path = None,
-            #sound_offset,
+            sound_offset = None,
     ):
         """
         Render the media
@@ -68,7 +68,7 @@ class RenderMedia(HookBaseClass):
             version,
             engine_settings,
             sound_path,
-            #sound_offset,
+            sound_offset,
         )
 
         old_motion_blur = maya.mel.eval('getAttr "hardwareRenderingGlobals.motionBlurEnable";')
@@ -136,7 +136,7 @@ class RenderMedia(HookBaseClass):
             version,
             engine_settings,
             sound_path,
-            #sound_offset,
+            sound_offset,
     ):
         """
         Build the playblast command arguments. This implementation grab the playblast arguments from Maya.

--- a/hooks/tk-maya/render_media.py
+++ b/hooks/tk-maya/render_media.py
@@ -38,6 +38,8 @@ class RenderMedia(HookBaseClass):
             description,
             version,
             engine_settings,
+            sound_path = None,
+            #sound_offset,
     ):
         """
         Render the media
@@ -65,6 +67,8 @@ class RenderMedia(HookBaseClass):
             description,
             version,
             engine_settings,
+            sound_path,
+            #sound_offset,
         )
 
         old_motion_blur = maya.mel.eval('getAttr "hardwareRenderingGlobals.motionBlurEnable";')
@@ -131,6 +135,8 @@ class RenderMedia(HookBaseClass):
             description,
             version,
             engine_settings,
+            sound_path,
+            #sound_offset,
     ):
         """
         Build the playblast command arguments. This implementation grab the playblast arguments from Maya.
@@ -148,6 +154,7 @@ class RenderMedia(HookBaseClass):
         :param str description:         Description to use in the slate for the output movie
         :param int version:             Version number to use for the output movie slate and burn-in
         :param dict engine_settings:    Engine specific settings to use for rendering
+        :param 
 
         :returns:               Playblast arguments
         :rtype:                 dict

--- a/python/tk_multi_reviewsubmission2/create_slate.py
+++ b/python/tk_multi_reviewsubmission2/create_slate.py
@@ -72,7 +72,7 @@ class CreateSlate(object):
             logo_path = logo_path.replace(os.sep, "/")
 
         sound_path = settings["sound_path"]
-        #sound_offset = settings["sound_offset"]
+        sound_offset = settings["sound_offset"]
 
         # ensure output path exists
         self.app.ensure_folder_exists(os.path.dirname(os.path.abspath(outputFile)))
@@ -106,7 +106,7 @@ class CreateSlate(object):
                 str(fps),
                 logo_path,
                 str(sound_path),
-                #sound_offset,
+                str(sound_offset),
             ],
             shell=True,
             stdout=subprocess.PIPE,

--- a/python/tk_multi_reviewsubmission2/create_slate.py
+++ b/python/tk_multi_reviewsubmission2/create_slate.py
@@ -71,6 +71,9 @@ class CreateSlate(object):
         if sgtk.util.is_windows():
             logo_path = logo_path.replace(os.sep, "/")
 
+        sound_path = settings["sound_path"]
+        #sound_offset = settings["sound_offset"]
+
         # ensure output path exists
         self.app.ensure_folder_exists(os.path.dirname(os.path.abspath(outputFile)))
 
@@ -102,6 +105,8 @@ class CreateSlate(object):
                 description,
                 str(fps),
                 logo_path,
+                str(sound_path),
+                #sound_offset,
             ],
             shell=True,
             stdout=subprocess.PIPE,

--- a/python/tk_multi_reviewsubmission2/review_dialog.py
+++ b/python/tk_multi_reviewsubmission2/review_dialog.py
@@ -212,6 +212,16 @@ class ReviewDialog(QtWidgets.QDialog):
                 maya.cmds.getAttr("defaultResolution.height")
             )
 
+
+            audio_nodes = maya.cmds.ls(type="audio")
+            self.audio_filename = None
+            for audio_node in audio_nodes:
+                if audio_node is None:  # Skip if the audio_node is None
+                    continue
+                self.audio_filename = maya.cmds.getAttr(f"{audio_node}.filename")
+                #self.audio_offset = maya.cmds.getAttr(f"{audio_node}.offset")
+
+
             self.use_antialiasing = QtWidgets.QCheckBox("Anti-aliasing", self)
             self.show_ornaments = QtWidgets.QCheckBox("Show ornaments", self)
             self.show_ornaments.setChecked(True)
@@ -291,6 +301,8 @@ class ReviewDialog(QtWidgets.QDialog):
             input_settings["resolution"] = self.validate_resolution()
             input_settings["description"] = self.validate_description()
             input_settings["version"] = self.file_fields.get("version")
+            input_settings["sound_path"] = self.audio_filename
+            #input_settings["sound_offset"] = self.audio_offset
 
             if self.current_engine.name == "tk-houdini":
                 engine_settings["mplay"] = self.validate_mplay()

--- a/python/tk_multi_reviewsubmission2/review_dialog.py
+++ b/python/tk_multi_reviewsubmission2/review_dialog.py
@@ -219,7 +219,7 @@ class ReviewDialog(QtWidgets.QDialog):
                 if audio_node is None:  # Skip if the audio_node is None
                     continue
                 self.audio_filename = maya.cmds.getAttr(f"{audio_node}.filename")
-                #self.audio_offset = maya.cmds.getAttr(f"{audio_node}.offset")
+                self.audio_offset = maya.cmds.getAttr(f"{audio_node}.offset")
 
 
             self.use_antialiasing = QtWidgets.QCheckBox("Anti-aliasing", self)
@@ -302,7 +302,7 @@ class ReviewDialog(QtWidgets.QDialog):
             input_settings["description"] = self.validate_description()
             input_settings["version"] = self.file_fields.get("version")
             input_settings["sound_path"] = self.audio_filename
-            #input_settings["sound_offset"] = self.audio_offset
+            input_settings["sound_offset"] = self.audio_offset
 
             if self.current_engine.name == "tk-houdini":
                 engine_settings["mplay"] = self.validate_mplay()

--- a/python/tk_multi_reviewsubmission2/slate.py
+++ b/python/tk_multi_reviewsubmission2/slate.py
@@ -42,6 +42,8 @@ task_name = sys.argv[12]
 description = sys.argv[13]
 fps = float(sys.argv[14])
 logo_path = sys.argv[15]
+sound_path = sys.argv[16]
+#sound_offset = int(float(sys.argv[17]))
 
 output_node = None
 
@@ -106,6 +108,10 @@ def __get_quicktime_settings():
         settings["mov64_codec"] = 14
         settings["mov64_quality_max"] = "3"
         settings["mov64_fps"] = fps
+        if sound_path is not None and os.path.isfile(sound_path):
+            settings["mov64_audiofile"] = sound_path
+        #settings["mov64_audio_offset"] = sound_offset
+        settings["mov64_units"] = "Frames"
 
         # setting output colorspace
         settings["colorspace"] = colorspace

--- a/python/tk_multi_reviewsubmission2/slate.py
+++ b/python/tk_multi_reviewsubmission2/slate.py
@@ -43,7 +43,7 @@ description = sys.argv[13]
 fps = float(sys.argv[14])
 logo_path = sys.argv[15]
 sound_path = sys.argv[16]
-#sound_offset = int(float(sys.argv[17]))
+sound_offset = int(float(sys.argv[17]))
 
 output_node = None
 
@@ -110,7 +110,7 @@ def __get_quicktime_settings():
         settings["mov64_fps"] = fps
         if sound_path is not None and os.path.isfile(sound_path):
             settings["mov64_audiofile"] = sound_path
-        #settings["mov64_audio_offset"] = sound_offset
+            settings["mov64_audio_offset"] = sound_offset - 1000
         settings["mov64_units"] = "Frames"
 
         # setting output colorspace

--- a/python/tk_multi_reviewsubmission2/slate.py
+++ b/python/tk_multi_reviewsubmission2/slate.py
@@ -108,7 +108,7 @@ def __get_quicktime_settings():
         settings["mov64_codec"] = 14
         settings["mov64_quality_max"] = "3"
         settings["mov64_fps"] = fps
-        if sound_path is not None and os.path.isfile(sound_path):
+        if os.path.isfile(sound_path):
             settings["mov64_audiofile"] = sound_path
             settings["mov64_audio_offset"] = sound_offset - 1000
         settings["mov64_units"] = "Frames"


### PR DESCRIPTION
This feature ensures that audio (if available) is always added to the playblast in ShotGrid. It has been designed to assist with reviewing lipsyncing and other moments where sound interacts with the animation.